### PR TITLE
Improve global vars for perlcc (DMUEY)

### DIFF
--- a/lib/Net/IDN/Encode.pm
+++ b/lib/Net/IDN/Encode.pm
@@ -33,10 +33,9 @@ Exporter::export_ok_tags(keys %EXPORT_TAGS);
 
 use Net::IDN::Punycode 1 ();
 
-our ($IDNA_PREFIX,$IDNA_DOT,$IDNA_ATSIGN);
-*IDNA_PREFIX 	= \'xn--';
-*IDNA_DOT	= \qr/[\.。．｡]/;
-*IDNA_ATSIGN	= \qr/[\@＠]/;
+our $IDNA_PREFIX = 'xn--';
+our $IDNA_DOT    = qr/(?:\.|\x{3002}|\x{ff0e}|\x{ff61}|\xe3\x80\x82|\xef\xbc\x8e|\xef\xbd\xa1)/;
+our $IDNA_ATSIGN = qr/(?:\@|\x{ff20}|\x{fe6b}|\xef\xbc\xa0|\xef\xb9\xab)/;
 
 require Net::IDN::UTS46; # after declaration of vars!
 


### PR DESCRIPTION
```
- simplify scalar-via-blob syntax
- account for both byte strings and unicode strings
- add SMALL COMMERCIAL AT to list of possible @ signs
```

Prompted by https://code.google.com/p/perl-compiler/issues/detail?id=143

All tests pass when run under 5.6.2, 5.8.8, 5.16.0, and 5.18.1
