### PR TITLE
Make generated arrays available at compile time

### DIFF
--- a/lib/Net/IDN/UTS46/_Mapping.PL
+++ b/lib/Net/IDN/UTS46/_Mapping.PL
@@ -123,14 +123,17 @@ sub write_is {
   }
   foreach(@_) { $_->[1] = undef if $_->[0] == $_->[1]; }
   
-  print "\nour \@$var_name = (";
+  print "\nour \@$var_name;";
+  print "\nBEGIN {";
+  print "\n  \@$var_name = (";
   my $nr = 0;
   foreach(@_) {
-    print "\n " if !($nr++ % 8);
-    # print "\n# ",$_->[2],"\n ";
+    print "\n    " if !($nr++ % 8);
+    # print "\n#   ",$_->[2],"\n ";
     print map { defined($_) ? sprintf(" 0x%04X,", $_) : " undef, " } @{$_}[0..1] ;
   }
-  print "\n);\n";
+  print "\n  );\n";
+  print "\n}\n";
 
   print "sub Is$sub_name { return _mk_prop(\@$var_name); };\n";
 }


### PR DESCRIPTION
A bug in earlier perls is being fixed in v5.30.  See
https://rt.perl.org/Ticket/Display.html?id=133860

This bug allowed this module to work, by luck.  But now it doesn't.  The
ticket whose link is given above has details, but in short, the variable
@IGNORED needs to be populated at compile time.  This patch changes so
the loop that generates the code causes all similar variables are
enclosed in BEGIN blocks.

Since this module is important to CPAN, with many other modules
dependent upon it, it would be good to get this fixed as soon as
possible.

There may be better solutions, but I found this without having to know
much about the workings of the module, and it seems safe to me.