### PR TITLE
update synopsis to use single quite

### DIFF
--- a/lib/Net/IDN/Encode.pm
+++ b/lib/Net/IDN/Encode.pm
@@ -117,8 +117,8 @@ Net::IDN::Encode - Internationalizing Domain Names in Applications (IDNA)
 =head1 SYNOPSIS
 
   use Net::IDN::Encode ':all';
-  my $a = domain_to_ascii("müller.example.org");
-  my $e = email_to_ascii("POSTMASTER@例。テスト");
+  my $a = domain_to_ascii('müller.example.org');
+  my $e = email_to_ascii('POSTMASTER@例。テスト');
   my $u = domain_to_unicode('EXAMPLE.XN--11B5BS3A9AJ6G');
 
 =head1 DESCRIPTION


### PR DESCRIPTION
Since there is a @ in the second example it gets interpreted as a array sigil, and running the code as-is (with `use utf8`) produces this error:

```
Non-ASCII characters in local-part at synopsis.pl line 4.
```

I updated the domain_to_ascii example as well just to keep the three examples consistent.